### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/casper307871/dj-bot-telegram-/security/code-scanning/1](https://github.com/casper307871/dj-bot-telegram-/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow. Since the workflow only checks out the repository and runs shell commands, it does not require write access to contents, issues, pull requests, or other resources. The minimal permission required for most workflows that do not modify repository state is `contents: read`. The `permissions` block should be added at the top level of the workflow (before `jobs:`) to apply to all jobs in the workflow unless more granular permissions are needed. Edit `.github/workflows/blank.yml`: insert the `permissions:` block with `contents: read` after the workflow `name:` definition and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
